### PR TITLE
Error unknown attribute 'album_id'

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -9,17 +9,16 @@ class AlbumsController < ApplicationController
 	end
 
 	def new
-		@artist = Artist.new
-		@album = @artist.albums.new
+		@album = Album.new
 
-		
+		@album.artist.new
 		
 	end
 
 	def create
-		@artist = Artist.new
+		@album = Album.find(params[:id])
 
-		@album = @artist.albums.new(album_params)
+		@artist = @album.artist.new(album_params)
 
 		if @album.save
 			redirect_to album_path(@album.id)
@@ -33,3 +32,6 @@ class AlbumsController < ApplicationController
 		params.require(:album).permit(:name, artists_attributes: [:name, :id])
 	end
 end
+
+
+

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -10,12 +10,15 @@ class AlbumsController < ApplicationController
 
 	def new
 		@album = Album.new
+
+		@album.artists.new
 		
 	end
 
 	def create
-		binding.pry
-		@album = Album.new(album_params)
+		@album = Album.find(params[:id])
+
+		@artist = @album.artist.new(album_params)
 
 		if @album.save
 			redirect_to album_path(@album.id)

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -7,4 +7,25 @@ class AlbumsController < ApplicationController
 	def show
 		@album = Album.find(params[:id])
 	end
+
+	def new
+		@album = Album.new
+		
+	end
+
+	def create
+		binding.pry
+		@album = Album.new(album_params)
+
+		if @album.save
+			redirect_to album_path(@album.id)
+		else
+			render :new
+		end
+	end
+
+	private
+	def album_params
+		params.require(:album).permit(:name, artists_attributes: [:name, :id])
+	end
 end

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -10,16 +10,12 @@ class AlbumsController < ApplicationController
 
 	def new
 		@album = Album.new
-
-		@album.artist.new
-		
+		@album.build_artist
 	end
 
 	def create
-		@album = Album.find(params[:id])
-
-		@artist = @album.artist.new(album_params)
-
+		@album = Album.new(album_params)
+binding.pry
 		if @album.save
 			redirect_to album_path(@album.id)
 		else
@@ -29,7 +25,7 @@ class AlbumsController < ApplicationController
 
 	private
 	def album_params
-		params.require(:album).permit(:name, artists_attributes: [:name, :id])
+		params.require(:album).permit(:name, artist_attributes: [:name, :id])
 	end
 end
 

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -15,7 +15,7 @@ class AlbumsController < ApplicationController
 
 	def create
 		@album = Album.new(album_params)
-binding.pry
+
 		if @album.save
 			redirect_to album_path(@album.id)
 		else

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -9,16 +9,17 @@ class AlbumsController < ApplicationController
 	end
 
 	def new
-		@album = Album.new
+		@artist = Artist.new
+		@album = @artist.albums.new
 
-		@album.artists.new
+		
 		
 	end
 
 	def create
-		@album = Album.find(params[:id])
+		@artist = Artist.new
 
-		@artist = @album.artist.new(album_params)
+		@album = @artist.albums.new(album_params)
 
 		if @album.save
 			redirect_to album_path(@album.id)

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -15,7 +15,7 @@ class AlbumsController < ApplicationController
 
 	def create
 		@album = Album.new(album_params)
-
+binding.pry
 		if @album.save
 			redirect_to album_path(@album.id)
 		else
@@ -25,7 +25,7 @@ class AlbumsController < ApplicationController
 
 	private
 	def album_params
-		params.require(:album).permit(:name, artist_attributes: [:name, :id])
+		params.require(:album).permit(:name, :genre, :release_date, :format, artist_attributes: [:name, :city, :url, :bio])
 	end
 end
 

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,2 +1,7 @@
 class Album < ActiveRecord::Base
+	belongs_to :artist
+	has_many :artists
+# This doesn't seem to really be doing anything to the form...
+	accepts_nested_attributes_for :artists
+	
 end

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,7 +1,8 @@
 class Album < ActiveRecord::Base
-	belongs_to :artist
 	has_many :artists
-# This doesn't seem to really be doing anything to the form...
+
 	accepts_nested_attributes_for :artists
+
+
 	
 end

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,4 +1,7 @@
 class Album < ActiveRecord::Base
 	belongs_to :artist
+	has_many :artists
+
+	accepts_nested_attributes_for :artist
 	
 end

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,8 +1,4 @@
 class Album < ActiveRecord::Base
-	has_many :artists
-
-	accepts_nested_attributes_for :artists
-
-
+	belongs_to :artist
 	
 end

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,6 +1,5 @@
 class Album < ActiveRecord::Base
 	belongs_to :artist
-	has_many :artists
 
 	accepts_nested_attributes_for :artist
 	

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,4 +1,6 @@
 class Artist < ActiveRecord::Base
-	belongs_to :album
+	has_many :albums
+
+	accepts_nested_attributes_for :albums
 
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,2 +1,4 @@
 class Artist < ActiveRecord::Base
+	has_many :albums
+	belongs_to :album
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,6 +1,6 @@
 class Artist < ActiveRecord::Base
 	has_many :albums
 
-	accepts_nested_attributes_for :albums
+	# accepts_nested_attributes_for :albums
 
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,4 +1,4 @@
 class Artist < ActiveRecord::Base
-	has_many :albums
 	belongs_to :album
+
 end

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -17,3 +17,5 @@
 		<% end %>
 	</tbody>
 </table>
+
+<%= link_to "Add An Album", new_album_path %>

--- a/app/views/albums/new.html.erb
+++ b/app/views/albums/new.html.erb
@@ -5,11 +5,44 @@
 	<%= form.text_field :name %>
 </div>
 
+<div>
+	<%= form.label "Genre" %><br>
+	<%= form.text_field :genre %>
+</div>
+
+<div>
+	<%= form.label "Release Date" %><br>
+	<%= form.text_field :release_date %>
+</div>
+
+<!-- This should be a dropdown -->
+<div>
+	<%= form.label "Format" %><br>
+	<%= form.text_field :format %>
+</div>
+
+
+
 <%= form.fields_for :artist do |artist| %>
 
 <div>
 	<%= artist.label "Artist Name(s)" %><br>
 	<%= artist.text_field :name %>
+</div>
+
+<div>
+	<%= artist.label "City" %><br>
+	<%= artist.text_field :city %>
+</div>
+
+<div>
+	<%= artist.label "Artist URL" %><br>
+	<%= artist.text_field :url %>
+</div>
+
+<div>
+	<%= artist.label "Biography" %><br>
+	<%= artist.text_area :bio %>
 </div>
 
 <% end %>

--- a/app/views/albums/new.html.erb
+++ b/app/views/albums/new.html.erb
@@ -1,0 +1,21 @@
+<%= form_for(@album) do |form| %>
+
+<div>
+	<%= form.label "Album Title" %><br>
+	<%= form.text_field :name %>
+</div>
+
+<%= form.fields_for :artist do |artist| %>
+
+<div>
+	<%= artist.label "Artist Name(s)" %><br>
+	<%= artist.text_field :name %>
+</div>
+
+<% end %>
+
+<div>
+	<%= form.submit %>
+</div>
+
+<% end %>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -3,7 +3,7 @@
 <p><%= @album.name %></p>
 
 <h3>Artist(s)</h3>
-<p><%= @album.artists.name %>
+<p><%= @album.artist.name %>
 
 <h3>Genre</h3>
 <p><%= @album.genre %></p>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -2,6 +2,9 @@
 <h1>Title</h1>
 <p><%= @album.name %></p>
 
+<h3>Artist(s)</h3>
+<p><%= @album.artists.name %>
+
 <h3>Genre</h3>
 <p><%= @album.genre %></p>
 
@@ -9,4 +12,4 @@
 <p><%= @album.release_date %></p>
 
 <%= link_to "Home", albums_path %>
-
+<%= link_to "Add An Album", new_album_path %>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -3,13 +3,25 @@
 <p><%= @album.name %></p>
 
 <h3>Artist(s)</h3>
-<p><%= @album.artist.name %>
+<p><%= @album.artist.name %></p>
+
+<h3>City</h3>
+<p><%= @album.artist.city %></p>
+
+<h3>URL</h3>
+<p><%= @album.artist.url %></p>
+
+<h3>Biography</h3>
+<p><%= @album.artist.bio %></p>
 
 <h3>Genre</h3>
 <p><%= @album.genre %></p>
 
 <h3>Release Date</h3>
 <p><%= @album.release_date %></p>
+
+<h3>Format</h3>
+<p><%= @album.format %></p>
 
 <%= link_to "Home", albums_path %>
 <%= link_to "Add An Album", new_album_path %>

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -31,3 +31,4 @@
 </p>
 
 <%= link_to 'Back', artists_path %>
+<%= link_to "Add An Album", new_album_path %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,28 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160811213737) do
+ActiveRecord::Schema.define(version: 20160812175834) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.inet     "current_sign_in_ip"
-    t.inet     "last_sign_in_ip"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-  end
-
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
   create_table "albums", force: :cascade do |t|
     t.integer  "artist_id"
@@ -52,5 +34,23 @@ ActiveRecord::Schema.define(version: 20160811213737) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  create_table "users", force: :cascade do |t|
+    t.string   "email",                  default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer  "sign_in_count",          default: 0,  null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet     "current_sign_in_ip"
+    t.inet     "last_sign_in_ip"
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+  end
+
+  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
 end

--- a/spec/features/acceptance/integration_create_ablum_spec.rb
+++ b/spec/features/acceptance/integration_create_ablum_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Album, type: :model do
+
+  def add_an_album(options)
+    :album_name = options[:name]
+    :artist_name = options[:artist_name]
+    visit "/albums"
+    click_link "Add An Album"
+    fill_in "Album Title", with: options[:name]
+    fill_in "Artist Name(s)", with: options[:artist_name]
+    click_button "Create Album"
+  end
+
+  describe "Add a new album" do
+
+    it "creates a new album by filling out the form" do
+      add_an_album
+    end
+end


### PR DESCRIPTION
Title: Getting an error when I try to call new `Artist` instance on a new `Album` instance

Body:

I can't get form to load, getting an error I don't understand.
1. Go to the `new` action in the `AlbumController` line: 11
2. Start server and visit `albums/new`
3. An error is shown for an unknown attribute (see below)

Expected: The `albums/new.html.erb` page loads and two text fields are displayed

Actual: I get an error page saying `unknown attribute 'album_id' for Artist`. There isn't an 'album_id' attribute shown in either of the migrations (`create_artist`, `create_album`).

When i've used `pry` to investigate the error I get:

`[1] pry(#<AlbumsController>)> @album.artists.new
ActiveRecord::UnknownAttributeError: unknown attribute 'album_id' for Artist.
from /Users/joshsalyer/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/activerecord-4.2.7/lib/active_record/attribute_assignment.rb:59:in` `rescue in _assign_attribute'`

What I've Tried: Passing in `@album.id` into `@album.artists.new` and loading `albums/new` without `@album.artists.new` in the `new` action. I'm not sure where `album_id` is coming from or where I'm suppose to be passing it in. There is an `artist_id` associated with the `Album` class but I thought that it should be filled in automatically since `Artist` `belongs_to :album` and `Album` `has_many :artists` (also added `accepts_nested_attributes_for :artists` to the `Album` model).
