### PR TITLE
fixed @format global variable, wasn't in hash format

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,3 +1,5 @@
+require 'pry'
+
 class HomeController < ApplicationController
 	if Rails.env.development?	
 		before_action :authenticate_user!
@@ -18,8 +20,7 @@ class HomeController < ApplicationController
 		
 		elsif params[:format]
 			@albums = Album.filter(Album.all, params[:format]).page(params[:page]).per(9)
-			@format = params['format']
-			
+			@format = Album.album_count(Album.uniq.pluck(:format))
 		elsif params[:query]
 			@albums = Search.keywordSearch(params[:query])
 			@albums = Album.where(id: @albums.map(&:id))

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -97,12 +97,14 @@ class Album < ActiveRecord::Base
 
 	def self.album_count(input)
         count = {}
-        if input == ["LP", "EP", "Single"]
-            column = :format
-        else
-            column = :genre
-        end
         input.each do |input|
+
+        	if (input == "LP") || (input == "EP") || (input == "Single")
+            	column = :format
+        	else
+           		column = :genre
+        	end
+
             album_count = Album.where(column => input)
             count[input] = album_count.count
         end


### PR DESCRIPTION
Originally for the index action with params['format'] selected, @format was saved as the value from params['format'] which returned a string. If you see at the very top @format was supposed to be a hash returned by the album_count function in the model.  Also, to get the correct count the logic for album_count was moved to the each block.

Related issue here https://github.com/omahacodeschool/vinyl-archive/issues/82
